### PR TITLE
Many changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,25 @@
 # Laravel Multilog
 
+This project is a fork of [karlomikus/multilog](https://github.com/karlomikus/multilog)
+
 [![Build Status](https://travis-ci.org/karlomikus/multilog.svg?branch=master)](https://travis-ci.org/karlomikus/multilog)
 [![Latest Stable Version](https://poser.pugx.org/karlomikus/multilog/v/stable)](https://packagist.org/packages/karlomikus/multilog)
 [![License](https://poser.pugx.org/karlomikus/multilog/license)](https://packagist.org/packages/karlomikus/multilog)
 
-Easily add multiple monolog channels to your Laravel 5.2.* application.
+Easily add multiple Monolog channels to your Laravel or Lumen application.
 
 ## Install
 
 Via Composer
 
 ``` bash
-$ composer require karlomikus/multilog
+composer require karlomikus/multilog
 ```
 
 Or add the package to your composer file:
 
 ``` json
-"karlomikus/multilog": "1.*"
+"karlomikus/multilog": "2.*"
 ```
 
 Next register service provider and facade in your `config/app.php` file:
@@ -29,13 +31,22 @@ Karlomikus\Multilog\MultilogServiceProvider::class
 'Multilog' => Karlomikus\Multilog\Facade::class
 ```
 
-And finally publish the config file:
+## Configuration
+
+With Laravel, you can publish the configuration file with:
 
 ``` bash
-$ php artisan vendor:publish
+php artisan vendor:publish
 ```
 
-## Configuration
+If you are using Lumen, please copy the example of
+[configuration file](src/Multilog/config/multilog.php)
+to your application `config` directory. Then add the following line to
+`bootstrap/app.php`:
+
+```php
+$app->configure('multilog');
+```
 
 All your channels are defined in `config/multilog.php` file.
 
@@ -43,24 +54,23 @@ By default you have two channels (request and info):
 
 ``` php
 // Request channel
-'request' => [
-    'stream' => 'request.log',
-    'daily'  => true,
-    'format' => [
-        'date'   => 'Y-m-d H:i:s',
-        'output' => "[%datetime%] %message% %context% %extra%\n",
-    ],
-],
+'request' => function ($channel) {
+    $logger = new Logger($channel);
+    ...
+    return $logger;
+},
 // Info channel
-'info' => [
-    'stream' => 'info.log',
-    'daily'  => false
-]
+'info' => function ($channel) {
+    $logger = new Logger($channel);
+    ...
+    return $logger;
+}
 ```
 
 ## Usage
 
 Using dependency injection:
+
 ``` php
 use Karlomikus\Multilog\Contracts\MultilogInterface;
 
@@ -75,6 +85,7 @@ public function __construct(MultilogInterface $multilog)
 ```
 
 Using facade:
+
 ``` php
 Multilog::channel('channel-name')->info('Information here...');
 
@@ -82,7 +93,36 @@ Multilog::channel('channel-name')->info('Information here...');
 Multilog::c('channel-name')->warning('Warning here...');
 ```
 
+## Redirecting Log facade calls to a Multilog channel
+
+If you wanna make sure Multilog is used, you can redirect all Log facade calls
+to Multilog by adding the following service provider:
+
+```php
+// Service provider
+Karlomikus\Multilog\LogServiceProvider::class
+```
+
+Then configure the default channel in your `config/multilog.php` file:
+
+```php
+'defaultChannel' => 'global',
+'channels' => [
+    'request' => function ($channel) {
+        $logger = new Logger($channel);
+        ...
+        return $logger;
+    },
+]
+```
+
 ## Change log
+
+### [2.0.0] - 2017-08-28
+
+* Change configuration format to use closures
+* Compatibility with Lumen
+* Possibility to redirect `Log` calls to a `Multilog` default channel
 
 ### [1.0.0] - 2016-03-06
 

--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,14 @@
         }
     ],
     "require": {
-        "php" : ">=5.5",
+        "php" : ">=7.1",
         "monolog/monolog": ">=1.11",
-        "illuminate/contracts": "5.*"
+        "psr/log": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "5.*",
         "mockery/mockery": "~0.9.2",
+        "illuminate/contracts": "5.*",
         "illuminate/support": "5.*"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,13 @@
     ],
     "require": {
         "php" : ">=5.5",
-        "monolog/monolog": ">=1.11"
+        "monolog/monolog": ">=1.11",
+        "illuminate/contracts": "5.*"
     },
     "require-dev": {
         "phpunit/phpunit": "5.*",
         "mockery/mockery": "~0.9.2",
-        "illuminate/contracts": "5.2.*",
-        "illuminate/support": "5.2.*"
+        "illuminate/support": "5.*"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,8 @@
         }
     ],
     "require": {
-        "php" : "~5.5",
-        "monolog/monolog": "~1.11"
+        "php" : ">=5.5",
+        "monolog/monolog": ">=1.11"
     },
     "require-dev": {
         "phpunit/phpunit": "5.*",

--- a/src/Multilog/LogRedirect.php
+++ b/src/Multilog/LogRedirect.php
@@ -2,10 +2,10 @@
 namespace Karlomikus\Multilog;
 
 use Illuminate\Contracts\Config\Repository;
-use Illuminate\Contracts\Logging\Log;
+use Psr\Log\LoggerInterface;
 use Karlomikus\Multilog\Contracts\MultilogInterface;
 
-class LogRedirect implements Log
+class LogRedirect implements LoggerInterface
 {
     protected $config;
     protected $multilog;

--- a/src/Multilog/LogRedirect.php
+++ b/src/Multilog/LogRedirect.php
@@ -1,0 +1,161 @@
+<?php
+namespace Karlomikus\Multilog;
+
+use Illuminate\Contracts\Config\Repository;
+use Illuminate\Contracts\Logging\Log;
+use Karlomikus\Multilog\Contracts\MultilogInterface;
+
+class LogRedirect implements Log
+{
+    protected $config;
+    protected $multilog;
+
+    /**
+     * Create a new log writer instance.
+     *
+     * @param  \Illuminate\Contracts\Config\Repository          $config
+     * @param  \Karlomikus\Multilog\Contracts\MultilogInterface $multilog
+     * @return void
+     */
+    public function __construct(Repository $config, MultilogInterface $multilog)
+    {
+        $this->config = $config;
+        $this->multilog = $multilog;
+    }
+
+    /**
+     * Log an alert message to the logs.
+     *
+     * @param  string  $message
+     * @param  array  $context
+     * @return void
+     */
+    public function alert($message, array $context = [])
+    {
+        $this->logWithDefaultChannel('alert', $message, $context);
+    }
+
+    /**
+     * Log a critical message to the logs.
+     *
+     * @param  string  $message
+     * @param  array  $context
+     * @return void
+     */
+    public function critical($message, array $context = [])
+    {
+        $this->logWithDefaultChannel('critical', $message, $context);
+    }
+
+    /**
+     * Log an error message to the logs.
+     *
+     * @param  string  $message
+     * @param  array  $context
+     * @return void
+     */
+    public function error($message, array $context = [])
+    {
+        $this->logWithDefaultChannel('error', $message, $context);
+    }
+
+    /**
+     * Log a warning message to the logs.
+     *
+     * @param  string  $message
+     * @param  array  $context
+     * @return void
+     */
+    public function warning($message, array $context = [])
+    {
+        $this->logWithDefaultChannel('warning', $message, $context);
+    }
+
+    /**
+     * Log a notice to the logs.
+     *
+     * @param  string  $message
+     * @param  array  $context
+     * @return void
+     */
+    public function notice($message, array $context = [])
+    {
+        $this->logWithDefaultChannel('notice', $message, $context);
+    }
+
+    /**
+     * Log an informational message to the logs.
+     *
+     * @param  string  $message
+     * @param  array  $context
+     * @return void
+     */
+    public function info($message, array $context = [])
+    {
+        $this->logWithDefaultChannel('info', $message, $context);
+    }
+
+    /**
+     * Log a debug message to the logs.
+     *
+     * @param  string  $message
+     * @param  array  $context
+     * @return void
+     */
+    public function debug($message, array $context = [])
+    {
+        $this->logWithDefaultChannel('debug', $message, $context);
+    }
+
+    /**
+     * Log a message to the logs.
+     *
+     * @param  string  $level
+     * @param  string  $message
+     * @param  array  $context
+     * @return void
+     */
+    public function log($level, $message, array $context = [])
+    {
+        $this->logWithDefaultChannel($level, $message, $context);
+    }
+
+    /**
+     * Register a file log handler.
+     *
+     * @param  string  $path
+     * @param  string  $level
+     * @return void
+     */
+    public function useFiles($path, $level = 'debug')
+    {
+        throw new \Exception('useFiles() cannot be called with MonologRedirection');
+    }
+
+    /**
+     * Register a daily file log handler.
+     *
+     * @param  string  $path
+     * @param  int     $days
+     * @param  string  $level
+     * @return void
+     */
+    public function useDailyFiles($path, $days = 0, $level = 'debug')
+    {
+        throw new \Exception('useDailyFiles() cannot be called with MonologRedirection');
+    }
+
+    /**
+     * Proxy message through Multilog default channel
+     *
+     * @param  string  $level
+     * @param  string  $message
+     * @param  array  $context
+     * @return void
+     */
+    protected function logWithDefaultChannel($level, $message, array $context = [])
+    {
+        $channel = $this->config->get('multilog.defaultChannel');
+        $this->multilog->channel($channel)->$level($message, $context);
+    }
+}

--- a/src/Multilog/LogServiceProvider.php
+++ b/src/Multilog/LogServiceProvider.php
@@ -1,0 +1,24 @@
+<?php
+namespace Karlomikus\Multilog;
+
+use Illuminate\Support\ServiceProvider;
+
+class LogServiceProvider extends ServiceProvider
+{
+    public function register()
+    {
+        $this->app->singleton('log', function () {
+            return $this->createLogger();
+        });
+    }
+
+    /**
+     * Create the logger.
+     *
+     * @return \Illuminate\LogRedirect
+     */
+    public function createLogger()
+    {
+        return $this->app->make(LogRedirect::class);
+    }
+}

--- a/src/Multilog/MultilogServiceProvider.php
+++ b/src/Multilog/MultilogServiceProvider.php
@@ -13,7 +13,7 @@ class MultilogServiceProvider extends ServiceProvider
         );
 
         $this->publishes([
-            __DIR__ . '/config/multilog.php' => config_path('multilog.php'),
+            __DIR__ . '/config/multilog.php' => app()->basePath() . '/config/multilog.php',
         ]);
     }
 }

--- a/src/Multilog/config/multilog.php
+++ b/src/Multilog/config/multilog.php
@@ -1,4 +1,7 @@
 <?php
+use Monolog\Handler\RotatingFileHandler;
+use Monolog\Handler\StreamHandler;
+use Monolog\Logger;
 
 /*
 |--------------------------------------------------------------------------
@@ -7,28 +10,30 @@
 |
 | Configure your log streams here
 |
-| Configuration options:
-| 'stream' => Log filename
-| 'daily' => Use rotating daily log files
-| 'format' => (Optional) Define monolog line formatter
-|
 */
 return [
+    // Uncomment to proxy Log::foo() to Multilog::channel('app')->foo()
+    // 'defaultChannel' => 'app',
 
-    // Request channel
-    'request' => [
-        'stream' => 'request.log',
-        'daily'  => true,
-        'format' => [
-            'date'   => 'Y-m-d H:i:s',
-            'output' => "[%datetime%] %message% %context% %extra%\n",
-        ],
+    'channels' => [
+        // Usage: Multilog::channel('app')->info('Hello world')
+        'app' => function ($channel) {
+            $logger = new Logger($channel);
+            $logger->pushHandler(new RotatingFileHandler(
+                storage_path('/logs/app.log'),
+                7,
+                Logger::INFO
+            ));
+            return $logger;
+        },
+
+        // Wildcard configuration for any channel starting with "industries.":
+        // Usage: Multilog::channel('industries.acme')->info('Hello world')
+        //        Multilog::channel('industries.wayne')->info('Foo bar')
+        'industries.*' => function ($channel) {
+            $logger = new Logger($channel);
+            $logger->pushHandler(new StreamHandler(storage_path('/logs/' . $channel . '.log')));
+            return $logger;
+        },
     ],
-
-    // Info channel
-    'info' => [
-        'stream' => 'info.log',
-        'daily'  => false
-    ],
-
 ];


### PR DESCRIPTION
Hi @karlomikus 

This PR adds the following changes:

* Compatibility with newer versions of Laravel and Lumen
* Wildcard channels. For example, you could make both `Multilog::channel('industries.acme')` and `Multilog::channel('industries.umbrella')` instantiate the logger based on the `industries.*` channel configuration in `config/multilog.php`
* `Log::something()` can be proxied to `Monolog::channel($defaultChannel)::something()`, so that all previous or third party log calls go through Multilog
* Now Multilog channels are configured using closures instead of arrays. This adds flexibility, but drops the easiness of using arrays to configure the logger.

I am not sure you will merge this PR because I have substantially changed the way `config/multilog.php` works, but I hope you give it a try and think about merging it and tagging as a new version.

This is a real world example with names changed:

```php
<?php
use Monolog\Handler\RotatingFileHandler;
use Monolog\Logger;

return [
    'defaultChannel' => 'app',
    'channels' => [
        'app' => function ($channel) {
            $logger = new Logger($channel);
            $logger->pushHandler(new RotatingFileHandler(
                storage_path('/logs/app.log'),
                7,
                Logger::INFO
            ));

            if (env('APP_DEBUG', false)) {
                $logger->pushHandler(new RotatingFileHandler(
                    storage_path('/logs/debug.log'),
                    7,
                    Logger::DEBUG
                ));
            }

            return $logger;
        },
        'industries.*' => function ($channel) {
            $logger = new Logger($channel);
            $logger->pushHandler(new RotatingFileHandler(
                storage_path('/logs/' . $channel . '.log'),
                7,
                Logger::DEBUG
            ));

            return $logger;
        },
    ]
];

```